### PR TITLE
Update kdeosiso_loop_mnt

### DIFF
--- a/live-iso/hooks/kdeosiso_loop_mnt
+++ b/live-iso/hooks/kdeosiso_loop_mnt
@@ -20,6 +20,7 @@ kdeosiso_loop_mount_handler () {
     msg "::: Setup a loop device from ${img_loop} located at device ${img_dev}"
     FSTYPE=$(blkid -o value -s TYPE -p ${img_dev} 2> /dev/null)
     if [ -n "${FSTYPE}" ]; then
+        mkdir -p /img_dev
         if mount -r -t "${FSTYPE}" ${img_dev} /img_dev > /dev/null 2>&1; then
             _dev_loop=$(losetup -f)
             losetup ${_dev_loop} /img_dev/${img_loop}


### PR DESCRIPTION
This will help to boot ISO if img_loop and img_dev params are set. I test it and works fine. Before build ISO, it is necessary to make install under live-uefi/live-iso to install hooks in initcpio.